### PR TITLE
chore: remove duration as input when uploading assets

### DIFF
--- a/actions/uploadAsset.js
+++ b/actions/uploadAsset.js
@@ -23,14 +23,6 @@ const uploadAsset = {
         required: true,
         helpText: 'Title of the asset',
       },
-      {
-        key: 'duration',
-        label: 'Duration (seconds)',
-        type: 'integer',
-        required: false,
-        default: '10',
-        helpText: 'How long should the asset be shown (in seconds)',
-      },
     ],
     perform: async (z, bundle) => {
       const response = await z.request({


### PR DESCRIPTION
* The step for uploading an asset doesn't use duration as input when calling the REST API endpoint, so deleting the duration input from the upload step would be fine.