### PR TITLE
chore: bump integration version to `v0.3.0`

### DIFF
--- a/docs/developer-documentation.md
+++ b/docs/developer-documentation.md
@@ -133,8 +133,8 @@ The integration is automatically deployed to Zapier when a new version tag is pu
 1. Create and push a new version tag:
 
    ```bash
-   git tag -a v0.1.0 -m "Initial release"
-   git push origin v0.1.0
+   git tag -a v0.3.0 -m "Initial release"
+   git push origin v0.3.0
    ```
 
 2. The GitHub Action will:
@@ -158,7 +158,7 @@ The integration is automatically deployed to Zapier when a new version tag is pu
 ## Version Management
 
 - Use semantic versioning (MAJOR.MINOR.PATCH)
-- Tag format: `v*.*.*` (e.g., v0.1.0, v1.0.0)
+- Tag format: `v*.*.*` (e.g., v0.3.0, v1.0.0)
 - Pre-release versions: Use `-beta`, `-alpha` suffixes
 
 ## License

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zapier-screenly",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zapier-screenly",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "dependencies": {
         "form-data": "^4.0.1",
         "glob": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zapier-screenly",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "description": "Screenly integration for Zapier platform",
   "main": "index.js",
   "type": "commonjs",


### PR DESCRIPTION
### Description

* Bumps the Screenly integration version from `0.1.0` to `v0.3.0`
* This PR needs to be merged first before creating and pushing a new tag.

### How Has This Been Tested?

- [x] Unit tests

### Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation (where applicable).
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules