### PR TITLE
chore: hide triggers that lists screens, playlists, and assets

### DIFF
--- a/.github/workflows/zapier-release.yml
+++ b/.github/workflows/zapier-release.yml
@@ -44,4 +44,4 @@ jobs:
       - name: Deploy to Zapier
         env:
           ZAPIER_DEPLOY_KEY: ${{ secrets.ZAPIER_DEPLOY_KEY }}
-        run: zapier push --skip-npm-install
+        run: zapier push

--- a/docs/developer-documentation.md
+++ b/docs/developer-documentation.md
@@ -133,8 +133,8 @@ The integration is automatically deployed to Zapier when a new version tag is pu
 1. Create and push a new version tag:
 
    ```bash
-   git tag -a v0.3.0 -m "Initial release"
-   git push origin v0.3.0
+   git tag -a v0.4.0 -m "New release"
+   git push origin v0.4.0
    ```
 
 2. The GitHub Action will:
@@ -158,7 +158,7 @@ The integration is automatically deployed to Zapier when a new version tag is pu
 ## Version Management
 
 - Use semantic versioning (MAJOR.MINOR.PATCH)
-- Tag format: `v*.*.*` (e.g., v0.3.0, v1.0.0)
+- Tag format: `v*.*.*` (e.g., v0.4.0, v1.0.0)
 - Pre-release versions: Use `-beta`, `-alpha` suffixes
 
 ## License

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zapier-screenly",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zapier-screenly",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
         "form-data": "^4.0.1",
         "glob": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zapier-screenly",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Screenly integration for Zapier platform",
   "main": "index.js",
   "type": "commonjs",

--- a/triggers/index.js
+++ b/triggers/index.js
@@ -6,6 +6,7 @@ const getScreens = {
   display: {
     label: 'Get Screens',
     description: 'Triggers when listing available Screenly screens.',
+    hidden: true,
   },
   operation: {
     perform: async (z, bundle) => {
@@ -33,6 +34,7 @@ const getPlaylists = {
   display: {
     label: 'Get Playlists',
     description: 'Triggers when listing available Screenly playlists.',
+    hidden: true,
   },
   operation: {
     perform: async (z, bundle) => {
@@ -60,6 +62,7 @@ const getAssets = {
   display: {
     label: 'Get Assets',
     description: 'Triggers when listing available Screenly assets.',
+    hidden: true,
   },
   operation: {
     perform: async (z, bundle) => {


### PR DESCRIPTION
### Description

The triggers that lists screens, playlists, and assets are not being used by end-users, so we hid them so that they will only be used by the  actions available in the integration.

### How Has This Been Tested?

- [x] Unit tests
- [x] Manual tests

### Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation (where applicable).
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules