### PR TITLE
fix: update help text for the API key

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,10 +24,9 @@ const authentication = {
       type: 'string',
       required: true,
       label: 'API Key',
-      helpText: 'Your Screenly API key from https://app.screenlyapp.com/settings/api-keys',
+      helpText: 'See [this page](https://support.screenly.io/hc/en-us/articles/35897560148371-How-to-Generate-a-Screenly-API-Token) for a guide on how to generate an API key for your Screenly account.',
     },
   ],
-  connectionLabel: '{{bundle.authData.api_key}}',
 };
 
 // Export the app definition


### PR DESCRIPTION
### Description

* Removed the `connectionLabel` option to default to a number-based labeling
* Updated the API key help text to include a valid link

### How Has This Been Tested?

- [x] Unit tests
- [x] Manual test

### Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation (where applicable).
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

### Screenshots

![image](https://github.com/user-attachments/assets/5f6c7674-4f15-449b-a3ed-189532b27a84)

![image](https://github.com/user-attachments/assets/52ac4744-76aa-4d55-98ae-ee37126b0d12)
