### PR TITLE
fix: complete workflow duration not being reflected

### DIFF
--- a/actions/complete-workflow.js
+++ b/actions/complete-workflow.js
@@ -168,6 +168,7 @@ const completeWorkflow = {
         body: {
           asset_id: asset.id,
           playlist_id: playlistId,
+          duration: bundle.inputData.duration || 10,
         },
       });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -368,6 +368,7 @@ describe('Complete Workflow', () => {
         title: 'Test Asset',
         playlist_id: 'playlist-123',
         screen_id: 'screen-123',
+        duration: 15,
       },
     };
 
@@ -402,6 +403,7 @@ describe('Complete Workflow', () => {
       .post('/api/v4/playlist-items/', {
         asset_id: 'asset-123',
         playlist_id: 'playlist-123',
+        duration: 15,
       })
       .reply(201, {
         id: 'item-123',
@@ -429,6 +431,7 @@ describe('Complete Workflow', () => {
         title: 'Test Asset',
         new_playlist_name: 'New Playlist',
         screen_id: 'screen-123',
+        duration: 15,
       },
     };
 
@@ -480,6 +483,7 @@ describe('Complete Workflow', () => {
       .post('/api/v4/playlist-items/', {
         asset_id: 'asset-123',
         playlist_id: 'playlist-123',
+        duration: 15,
       })
       .reply(201, {
         id: 'item-123',


### PR DESCRIPTION
### Description

For instance, if I set the input duration to 17 in the Complete Workflow action, the playlist item's duration (as seen in the web console) is set t o default and not 17.

### How Has This Been Tested?

- [x] Unit tests
- [x] Manual tests

### Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation (where applicable).
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules