### PR TITLE
chore: move common API calls to `utils.js`

### DIFF
--- a/actions/assign-screen-to-playlist.js
+++ b/actions/assign-screen-to-playlist.js
@@ -27,34 +27,10 @@ const assignScreenToPlaylist = {
       },
     ],
     perform: async (z, bundle) => {
-      let screenId = bundle.inputData.screen_id;
-      let playlistId = bundle.inputData.playlist_id;
-
-      let labelToPlaylistResponse = await z.request({
-        url: `https://api.screenlyapp.com/api/v4/labels/playlists`,
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Token ${bundle.authData.api_key}`,
-          'Prefer': 'return=representation',
-        },
-        body: {
-          playlist_id: playlistId,
-          label_id: screenId,
-        },
-        skipThrowForStatus: true,
+      return await utils.assignPlaylistToScreen(z, bundle, {
+        screenId: bundle.inputData.screen_id,
+        playlistId: bundle.inputData.playlist_id,
       });
-
-      if (labelToPlaylistResponse.status === 409) {
-        z.console.log('Playlist already assigned to screen');
-      } else {
-        utils.handleError(labelToPlaylistResponse, 'Failed to assign playlist to screen');
-      }
-
-      return {
-        screen_id: screenId,
-        playlist_id: playlistId,
-      };
     },
     sample: {
       screen_id: 1,

--- a/actions/schedule-playlist-item.js
+++ b/actions/schedule-playlist-item.js
@@ -37,34 +37,11 @@ const schedulePlaylistItem = {
     perform: async (z, bundle) => {
       await utils.waitForAssetReady(z, bundle.inputData.asset_id, bundle.authData.api_key);
 
-      // Now proceed with adding to playlist
-      const payload = {
-        asset_id: bundle.inputData.asset_id,
-        playlist_id: bundle.inputData.playlist_id,
-      };
-
-      if (bundle.inputData.duration) {
-        payload.duration = bundle.inputData.duration;
-      }
-
-      const response = await z.request({
-        url: 'https://api.screenlyapp.com/api/v4/playlist-items/',
-        method: 'POST',
-        headers: {
-          'Authorization': `Token ${bundle.authData.api_key}`,
-          'Content-Type': 'application/json',
-          'Prefer': 'return=representation',
-        },
-        body: payload,
+      return await utils.createPlaylistItem(z, bundle, {
+        assetId: bundle.inputData.asset_id,
+        playlistId: bundle.inputData.playlist_id,
+        duration: bundle.inputData.duration,
       });
-
-      const assets = utils.handleError(response, 'Failed to add asset to playlist');
-
-      if (assets.length === 0) {
-        throw new Error('No assets returned from the Screenly API');
-      }
-
-      return assets[0];
     },
     sample: {
       id: 1,

--- a/actions/upload-asset.js
+++ b/actions/upload-asset.js
@@ -25,28 +25,10 @@ const uploadAsset = {
       },
     ],
     perform: async (z, bundle) => {
-      const response = await z.request({
-        url: 'https://api.screenlyapp.com/api/v4/assets/',
-        method: 'POST',
-        headers: {
-          'Authorization': `Token ${bundle.authData.api_key}`,
-          'Content-Type': 'application/json',
-          'Prefer': 'return=representation',
-        },
-        body: {
-          title: bundle.inputData.title,
-          source_url: bundle.inputData.file,
-          disable_verification: false
-        },
+      return await utils.createAsset(z, bundle, {
+        title: bundle.inputData.title,
+        sourceUrl: bundle.inputData.file,
       });
-
-      const assets = utils.handleError(response, 'Failed to upload asset');
-
-      if (assets.length === 0) {
-        throw new Error('No assets returned from the Screenly API');
-      }
-
-      return assets[0];
     },
     sample: {
       id: 1,

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,0 +1,168 @@
+const zapier = require('zapier-platform-core');
+const nock = require('nock');
+const utils = require('../utils');
+const { READY_STATES } = require('../constants');
+
+const TEST_API_KEY = 'test-api-key';
+
+describe('Utils', () => {
+  beforeEach(() => {
+    nock.cleanAll();
+  });
+
+  describe('getLabel', () => {
+    it('successfully fetches a label', async () => {
+      const z = {
+        request: jest.fn().mockResolvedValue({
+          status: 200,
+          json: [{ id: 'label-123', name: 'test-label' }]
+        }),
+        authData: { api_key: TEST_API_KEY },
+      };
+      const bundle = { authData: { api_key: TEST_API_KEY } };
+
+      const label = await utils.getLabel(z, bundle, { name: 'test-label' });
+      expect(label.id).toBe('label-123');
+      expect(label.name).toBe('test-label');
+    });
+
+    it('throws error when no labels found', async () => {
+      const z = {
+        request: jest.fn().mockResolvedValue({
+          status: 200,
+          json: []
+        }),
+        authData: { api_key: TEST_API_KEY },
+      };
+      const bundle = { authData: { api_key: TEST_API_KEY } };
+
+      await expect(utils.getLabel(z, bundle, { name: 'test-label' }))
+        .rejects.toThrow('No labels returned from the Screenly API');
+    });
+  });
+
+  describe('getPlaylistsByLabel', () => {
+    it('successfully fetches playlists by label', async () => {
+      const z = {
+        request: jest.fn().mockResolvedValue({
+          status: 200,
+          json: [
+            { playlist_id: 'playlist-1' },
+            { playlist_id: 'playlist-2' },
+          ]
+        }),
+        authData: { api_key: TEST_API_KEY },
+      };
+      const bundle = { authData: { api_key: TEST_API_KEY } };
+
+      const playlists = await utils.getPlaylistsByLabel(z, bundle, { labelId: 'label-123' });
+      expect(playlists).toHaveLength(2);
+      expect(playlists[0].playlist_id).toBe('playlist-1');
+    });
+
+    it('handles error response', async () => {
+      const z = {
+        request: jest.fn().mockResolvedValue({
+          status: 404,
+          json: { error: 'Not found' }
+        }),
+        authData: { api_key: TEST_API_KEY },
+      };
+      const bundle = { authData: { api_key: TEST_API_KEY } };
+
+      await expect(utils.getPlaylistsByLabel(z, bundle, { labelId: 'label-123' }))
+        .rejects.toThrow('Failed to fetch playlist to labels');
+    });
+  });
+
+  describe('deletePlaylist', () => {
+    it('successfully deletes a playlist', async () => {
+      const z = {
+        request: jest.fn().mockResolvedValue({
+          status: 200,
+          json: {}
+        }),
+        authData: { api_key: TEST_API_KEY },
+      };
+      const bundle = { authData: { api_key: TEST_API_KEY } };
+
+      const result = await utils.deletePlaylist(z, bundle, { playlistId: 'playlist-123' });
+      expect(result).toBe(true);
+    });
+
+    it('handles failed deletion', async () => {
+      const z = {
+        request: jest.fn().mockResolvedValue({
+          status: 404,
+          json: { error: 'Not found' }
+        }),
+        authData: { api_key: TEST_API_KEY },
+      };
+      const bundle = { authData: { api_key: TEST_API_KEY } };
+
+      const result = await utils.deletePlaylist(z, bundle, { playlistId: 'playlist-123' });
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('createPlaylist', () => {
+    it('successfully creates a playlist', async () => {
+      const z = {
+        request: jest.fn().mockResolvedValue({
+          status: 201,
+          json: [{
+            id: 'playlist-123',
+            title: 'Test Playlist',
+            predicate: 'TRUE',
+          }]
+        }),
+        authData: { api_key: TEST_API_KEY },
+      };
+      const bundle = { authData: { api_key: TEST_API_KEY } };
+
+      const playlist = await utils.createPlaylist(z, bundle, {
+        title: 'Test Playlist',
+        predicate: 'TRUE',
+      });
+      expect(playlist.id).toBe('playlist-123');
+      expect(playlist.title).toBe('Test Playlist');
+    });
+
+    it('throws error when no playlist returned', async () => {
+      const z = {
+        request: jest.fn().mockResolvedValue({
+          status: 201,
+          json: []
+        }),
+        authData: { api_key: TEST_API_KEY },
+      };
+      const bundle = { authData: { api_key: TEST_API_KEY } };
+
+      await expect(utils.createPlaylist(z, bundle, {
+        title: 'Test Playlist',
+        predicate: 'TRUE',
+      })).rejects.toThrow('No playlists returned from the Screenly API');
+    });
+  });
+
+  describe('waitForAssetReady', () => {
+    it('waits for asset to be ready', async () => {
+      const z = {
+        request: jest.fn()
+          .mockResolvedValueOnce({
+            status: 200,
+            json: [{ status: '' }]
+          })
+          .mockResolvedValueOnce({
+            status: 200,
+            json: [{ status: 'finished' }]
+          }),
+        console: { log: jest.fn() },
+      };
+
+      const status = await utils.waitForAssetReady(z, 'asset-123', TEST_API_KEY);
+      expect(status).toBe('finished');
+      expect(z.console.log).toHaveBeenCalledWith('Asset asset-123 status: finished');
+    });
+  });
+});

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,7 +1,5 @@
-const zapier = require('zapier-platform-core');
 const nock = require('nock');
 const utils = require('../utils');
-const { READY_STATES } = require('../constants');
 
 const TEST_API_KEY = 'test-api-key';
 

--- a/utils.js
+++ b/utils.js
@@ -44,8 +44,175 @@ const waitForAssetReady = async (z, assetId, authToken) => {
   return assetStatus;
 };
 
+const createAsset = async (z, bundle, { title, sourceUrl, disableVerification = false }) => {
+  const response = await z.request({
+    url: 'https://api.screenlyapp.com/api/v4/assets/',
+    method: 'POST',
+    headers: {
+      'Authorization': `Token ${bundle.authData.api_key}`,
+      'Content-Type': 'application/json',
+      'Prefer': 'return=representation',
+    },
+    body: {
+      title,
+      source_url: sourceUrl,
+      disable_verification: disableVerification
+    },
+  });
+
+  const assets = handleError(response, 'Failed to upload asset');
+
+  if (assets.length === 0) {
+    throw new Error('No assets returned from the Screenly API');
+  }
+
+  return assets[0];
+};
+
+const createPlaylistItem = async (z, bundle, { assetId, playlistId, duration }) => {
+  const payload = {
+    asset_id: assetId,
+    playlist_id: playlistId,
+  };
+
+  if (duration) {
+    payload.duration = duration;
+  }
+
+  const response = await z.request({
+    url: 'https://api.screenlyapp.com/api/v4/playlist-items/',
+    method: 'POST',
+    headers: {
+      'Authorization': `Token ${bundle.authData.api_key}`,
+      'Content-Type': 'application/json',
+      'Prefer': 'return=representation',
+    },
+    body: payload,
+  });
+
+  const items = handleError(response, 'Failed to add asset to playlist');
+
+  if (items.length === 0) {
+    throw new Error('No playlist items returned from the Screenly API');
+  }
+
+  return items[0];
+};
+
+const assignPlaylistToScreen = async (z, bundle, { screenId, playlistId }) => {
+  const response = await z.request({
+    url: `https://api.screenlyapp.com/api/v4/labels/playlists`,
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Token ${bundle.authData.api_key}`,
+      'Prefer': 'return=representation',
+    },
+    body: {
+      playlist_id: playlistId,
+      label_id: screenId,
+    },
+    skipThrowForStatus: true,
+  });
+
+  if (response.status === 409) {
+    z.console.log('Playlist already assigned to screen');
+  } else {
+    handleError(response, 'Failed to assign playlist to screen');
+  }
+
+  return {
+    screen_id: screenId,
+    playlist_id: playlistId,
+    message: 'Successfully assigned playlist to screen',
+  };
+};
+
+const createPlaylist = async (z, bundle, { title, predicate }) => {
+  const response = await z.request({
+    url: 'https://api.screenlyapp.com/api/v4/playlists',
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Token ${bundle.authData.api_key}`,
+      'Prefer': 'return=representation',
+    },
+    body: {
+      title,
+      predicate,
+    },
+  });
+
+  const playlists = handleError(response, 'Failed to create playlist');
+
+  if (playlists.length === 0) {
+    throw new Error('No playlists returned from the Screenly API');
+  }
+
+  return playlists[0];
+};
+
+const getLabel = async (z, bundle, { name }) => {
+  const queryParams = { name: `eq.${name}` };
+  const queryString = Object.keys(queryParams)
+    .map(key => `${key}=${queryParams[key]}`)
+    .join('&');
+
+  const response = await z.request({
+    url: `https://api.screenlyapp.com/api/v4/labels/?${queryString}`,
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Token ${bundle.authData.api_key}`,
+      'Prefer': 'return=representation',
+    },
+  });
+
+  const labels = handleError(response, 'Failed to fetch labels');
+  if (labels.length === 0) {
+    throw new Error('No labels returned from the Screenly API');
+  }
+  return labels[0];
+};
+
+const getPlaylistsByLabel = async (z, bundle, { labelId }) => {
+  const response = await z.request({
+    url: `https://api.screenlyapp.com/api/v4/labels/playlists?label_id=eq.${labelId}`,
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Token ${bundle.authData.api_key}`,
+      'Prefer': 'return=representation',
+    },
+  });
+
+  return handleError(response, 'Failed to fetch playlist to labels');
+};
+
+const deletePlaylist = async (z, bundle, { playlistId }) => {
+  const response = await z.request({
+    url: `https://api.screenlyapp.com/api/v4/playlists/?id=eq.${playlistId}/`,
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Token ${bundle.authData.api_key}`,
+      'Prefer': 'return=representation',
+    },
+    skipThrowForStatus: true,
+  });
+
+  return response.status === 200;
+};
+
 module.exports = {
   handleError,
   makeRequest,
   waitForAssetReady,
+  createAsset,
+  createPlaylistItem,
+  assignPlaylistToScreen,
+  createPlaylist,
+  getLabel,
+  getPlaylistsByLabel,
+  deletePlaylist,
 };


### PR DESCRIPTION
### Description

Resolves code duplication in the code, more specifically in API calls.

### How Has This Been Tested?

* Unit tests

### Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation (where applicable).
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules