### PR TITLE
chore: bump `zapier-platform-core` to `16.3.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "glob": "^11.0.0",
         "node-fetch": "^3.3.2",
         "rimraf": "^6.0.1",
-        "zapier-platform-core": "15.19.0"
+        "zapier-platform-core": "16.3.0"
       },
       "devDependencies": {
         "@babel/core": "^7.26.0",
@@ -2718,9 +2718,9 @@
       "license": "ISC"
     },
     "node_modules/@zapier/secret-scrubber": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@zapier/secret-scrubber/-/secret-scrubber-1.1.1.tgz",
-      "integrity": "sha512-4w0lsz8lpsl/+c1u8h5LDNioCdLloPobryH7voawgO6hoPkwJxYhXB1xZYLAxycFSZmCXajRmzZyzma26pdIOQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@zapier/secret-scrubber/-/secret-scrubber-1.1.2.tgz",
+      "integrity": "sha512-a4siIYOLgLkfd4TY5FP2gO0Qu4I4kf781wnyR2aMMZbI7CmXD1VS3JcOjPpVHDlC0GKynF/yJd+CmZLkfIUEYg==",
       "license": "ISC",
       "dependencies": {
         "create-hash": "^1.2.0",
@@ -3865,12 +3865,15 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "12.0.4",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-12.0.4.tgz",
-      "integrity": "sha512-oWdqbSywffzH1l4WXKPHWA0TWYpqp7IyLfqjipT4upoIFS0HPMqtNotykQpD4iIg0BqtNmdgPCh2WMvMt7yTiw==",
+      "version": "16.4.6",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.6.tgz",
+      "integrity": "sha512-JhcR/+KIjkkjiU8yEpaB/USlzVi3i5whwOjpIRNGi9svKEXZSe+Qp6IWAjFjv+2GViAoDRCUv/QLNziQxsLqDg==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/eastasianwidth": {
@@ -9235,23 +9238,23 @@
       }
     },
     "node_modules/zapier-platform-core": {
-      "version": "15.19.0",
-      "resolved": "https://registry.npmjs.org/zapier-platform-core/-/zapier-platform-core-15.19.0.tgz",
-      "integrity": "sha512-KWyvuZ+QnooOknFl3AW6HObbXdz1FZYclN46EwUeQEd1xIjHwr+WdQwOYPJJM6jwSBkh0Fb7MMVhZQQ0VmPlCg==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/zapier-platform-core/-/zapier-platform-core-16.3.0.tgz",
+      "integrity": "sha512-yCUoUeHVUQOufo4OCOtT9KO7brXlwS+18I4rZ31g4tXPCdyqCSyIIeuN9/p+R/fpUuLXhdupMJNt3xlsUr6zEQ==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@zapier/secret-scrubber": "^1.1.1",
+        "@zapier/secret-scrubber": "^1.1.2",
         "bluebird": "3.7.2",
         "content-disposition": "0.5.4",
-        "dotenv": "12.0.4 ",
-        "form-data": "4.0.0",
+        "dotenv": "16.4.6",
+        "form-data": "4.0.1",
         "lodash": "4.17.21",
         "mime-types": "2.1.35",
         "node-abort-controller": "3.1.1",
-        "node-fetch": "2.6.7",
+        "node-fetch": "2.7.0",
         "oauth-sign": "0.9.0",
-        "semver": "7.5.2",
-        "zapier-platform-schema": "15.19.0"
+        "semver": "7.6.3",
+        "zapier-platform-schema": "16.3.0"
       },
       "engines": {
         "node": ">=16",
@@ -9271,36 +9274,10 @@
         "undici-types": "~6.19.2"
       }
     },
-    "node_modules/zapier-platform-core/node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/zapier-platform-core/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/zapier-platform-core/node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -9318,13 +9295,10 @@
       }
     },
     "node_modules/zapier-platform-core/node_modules/semver": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
-      "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -9361,16 +9335,10 @@
         "webidl-conversions": "^3.0.0"
       }
     },
-    "node_modules/zapier-platform-core/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
-    },
     "node_modules/zapier-platform-schema": {
-      "version": "15.19.0",
-      "resolved": "https://registry.npmjs.org/zapier-platform-schema/-/zapier-platform-schema-15.19.0.tgz",
-      "integrity": "sha512-c3lkrIm3/KaAOXGgayhQtXiH7ODtn1lxBTK5marU30yuyO+7WMCpxW+H79yVrfeiDyR7Dhy7LyKtoKw7pEWq+Q==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/zapier-platform-schema/-/zapier-platform-schema-16.3.0.tgz",
+      "integrity": "sha512-mJiBiO/8Y3iZkTmqrhSNhi5f+lZkhnVYc0xQg1vPtIN4Joip6XO5NhRHLqT/GWdYGaxROXqdgL7SrzC5uuHaBA==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "jsonschema": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "glob": "^11.0.0",
     "node-fetch": "^3.3.2",
     "rimraf": "^6.0.1",
-    "zapier-platform-core": "15.19.0"
+    "zapier-platform-core": "16.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.26.0",


### PR DESCRIPTION
### Description

Bumps `zapier-platform-core` from `15.19` to `16.3.0`

### How Has This Been Tested?

- [x] Unit tests
- [x] Manual tests

### Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation (where applicable).
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

### Screenshots

Here's a screenshot of my integrations page.

![image](https://github.com/user-attachments/assets/fe619fa7-5a01-49b3-9689-4cdba8e438c1)
