### PR TITLE
chore(deps): bump `zapier-platform-core` to `16.5.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "glob": "^11.0.0",
         "node-fetch": "^3.3.2",
         "rimraf": "^6.0.1",
-        "zapier-platform-core": "16.3.1"
+        "zapier-platform-core": "16.5.0"
       },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^8.28.0",
@@ -9967,9 +9967,9 @@
       }
     },
     "node_modules/zapier-platform-core": {
-      "version": "16.3.1",
-      "resolved": "https://registry.npmjs.org/zapier-platform-core/-/zapier-platform-core-16.3.1.tgz",
-      "integrity": "sha512-s2akkN972hoxELufFk4K7vTjNU4CWAEqP7SgzEwXURM38Oh9QI/08JHmxrjD4qUZyezvj309wXG96E0V0Ngu5w==",
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/zapier-platform-core/-/zapier-platform-core-16.5.0.tgz",
+      "integrity": "sha512-HNnrzk1s5vGG5IE/Kt5eO8EtcEQ79HTOpIEEk3AaPSSt+r3/KGKVrbbNh1XmV0u3GyPJ4cH2NtR6UdD3nshQyg==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@zapier/secret-scrubber": "^1.1.2",
@@ -9983,7 +9983,7 @@
         "node-fetch": "2.7.0",
         "oauth-sign": "0.9.0",
         "semver": "7.6.3",
-        "zapier-platform-schema": "16.3.1"
+        "zapier-platform-schema": "16.5.0"
       },
       "engines": {
         "node": ">=16",
@@ -10065,9 +10065,9 @@
       }
     },
     "node_modules/zapier-platform-schema": {
-      "version": "16.3.1",
-      "resolved": "https://registry.npmjs.org/zapier-platform-schema/-/zapier-platform-schema-16.3.1.tgz",
-      "integrity": "sha512-/71K04eoDEu/bcXm4E6GK0P+jhdZ3gMNuabCS/BLkjwrt9qVahnMY4U/nZEI+u/QqL7RPW0eTic9RnRkHu7rNA==",
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/zapier-platform-schema/-/zapier-platform-schema-16.5.0.tgz",
+      "integrity": "sha512-EBVtU67ICz33k6zydQ3YNy72ydSbBsMVlBlTB7mQP8pByxdhmzITro/xdhj/zhb8npBo9v1OrX4qcCgmLbIkqw==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "jsonschema": "1.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "glob": "^11.0.0",
         "node-fetch": "^3.3.2",
         "rimraf": "^6.0.1",
-        "zapier-platform-core": "16.3.0"
+        "zapier-platform-core": "16.3.1"
       },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^8.28.0",
@@ -9941,9 +9941,9 @@
       }
     },
     "node_modules/zapier-platform-core": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/zapier-platform-core/-/zapier-platform-core-16.3.0.tgz",
-      "integrity": "sha512-yCUoUeHVUQOufo4OCOtT9KO7brXlwS+18I4rZ31g4tXPCdyqCSyIIeuN9/p+R/fpUuLXhdupMJNt3xlsUr6zEQ==",
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/zapier-platform-core/-/zapier-platform-core-16.3.1.tgz",
+      "integrity": "sha512-s2akkN972hoxELufFk4K7vTjNU4CWAEqP7SgzEwXURM38Oh9QI/08JHmxrjD4qUZyezvj309wXG96E0V0Ngu5w==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@zapier/secret-scrubber": "^1.1.2",
@@ -9957,7 +9957,7 @@
         "node-fetch": "2.7.0",
         "oauth-sign": "0.9.0",
         "semver": "7.6.3",
-        "zapier-platform-schema": "16.3.0"
+        "zapier-platform-schema": "16.3.1"
       },
       "engines": {
         "node": ">=16",
@@ -10039,9 +10039,9 @@
       }
     },
     "node_modules/zapier-platform-schema": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/zapier-platform-schema/-/zapier-platform-schema-16.3.0.tgz",
-      "integrity": "sha512-mJiBiO/8Y3iZkTmqrhSNhi5f+lZkhnVYc0xQg1vPtIN4Joip6XO5NhRHLqT/GWdYGaxROXqdgL7SrzC5uuHaBA==",
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/zapier-platform-schema/-/zapier-platform-schema-16.3.1.tgz",
+      "integrity": "sha512-/71K04eoDEu/bcXm4E6GK0P+jhdZ3gMNuabCS/BLkjwrt9qVahnMY4U/nZEI+u/QqL7RPW0eTic9RnRkHu7rNA==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "jsonschema": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "glob": "^11.0.0",
     "node-fetch": "^3.3.2",
     "rimraf": "^6.0.1",
-    "zapier-platform-core": "16.3.1"
+    "zapier-platform-core": "16.5.0"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.28.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "glob": "^11.0.0",
     "node-fetch": "^3.3.2",
     "rimraf": "^6.0.1",
-    "zapier-platform-core": "16.3.0"
+    "zapier-platform-core": "16.3.1"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.28.0",


### PR DESCRIPTION
### Description

- Bumps `zapier-platform-core` from `"16.3.0` to `16.5.0`

### How has this been tested?

- [x] Unit tests
- [x] Manual tests

### Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation (where applicable).
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
