### PR TITLE
fix: exclude Edge App and Edge App files from assets query

### DIFF
--- a/src/triggers/get-assets.ts
+++ b/src/triggers/get-assets.ts
@@ -11,8 +11,13 @@ const getAssets = {
   },
   operation: {
     perform: async (z: ZObject, bundle: Bundle): Promise<object> => {
+      const queryParams = [
+        'and=(type.not.eq.edge-app-file,type.not.eq.edge-app)',
+        'or=(status.eq.downloading,status.eq.processing,status.eq.finished)',
+      ].join('&');
+
       const response = await z.request({
-        url: 'https://api.screenlyapp.com/api/v4/assets/',
+        url: `https://api.screenlyapp.com/api/v4/assets/?${queryParams}`,
         headers: {
           Authorization: `Token ${bundle.authData.api_key}`,
         },

--- a/test/dynamic-dropdowns.test.ts
+++ b/test/dynamic-dropdowns.test.ts
@@ -42,8 +42,13 @@ describe('Dynamic Dropdowns', () => {
       },
     };
 
+    const queryParams = [
+      'and=(type.not.eq.edge-app-file,type.not.eq.edge-app)',
+      'or=(status.eq.downloading,status.eq.processing,status.eq.finished)',
+    ].join('&');
+
     nock('https://api.screenlyapp.com')
-      .get('/api/v4/assets/')
+      .get(`/api/v4/assets/?${queryParams}`)
       .matchHeader('Authorization', `Token ${TEST_API_KEY}`)
       .reply(200, [
         { id: 'asset-1', title: 'Asset 1' },


### PR DESCRIPTION
### Description

- Excluded Edge App and Edge App files from assets query so that the drop-down list wouldn't display too much content.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Unit tests
- [x] Integration tests

### Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation (where applicable).
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

### Screenshots

#### Before

![image](https://github.com/user-attachments/assets/69b9e1d8-1336-4143-8d02-95b1c6396bda)

#### After

![image](https://github.com/user-attachments/assets/3e171fc2-5062-44d2-8a34-6d0dc8fdfc4b)