### PR TITLE
chore: include metadata for assets created by Zapier

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,7 @@
 // Utility functions for Screenly Zapier integration
 
 import { ZObject, Bundle, HttpResponse } from 'zapier-platform-core';
-import { READY_STATES } from './constants.js';
+import { READY_STATES, ZAPIER_TAG } from './constants.js';
 import {
   Asset,
   PlaylistItem,
@@ -67,6 +67,9 @@ const createAsset = async (
       title,
       source_url: sourceUrl,
       disable_verification: disableVerification,
+      metadata: {
+        tags: [ZAPIER_TAG],
+      },
     },
   });
 

--- a/test/complete-workflow.test.ts
+++ b/test/complete-workflow.test.ts
@@ -2,7 +2,7 @@ import zapier from 'zapier-platform-core';
 import App from '../src/index.js';
 import nock from 'nock';
 import { describe, beforeEach, test, expect } from 'vitest';
-
+import { ZAPIER_TAG } from '../src/constants.js';
 const TEST_API_KEY = 'valid-api-key';
 const appTester = zapier.createAppTester(App);
 
@@ -32,6 +32,9 @@ describe('Complete Workflow', () => {
         title: 'Test Asset',
         source_url: 'https://example.com/test.jpg',
         disable_verification: false,
+        metadata: {
+          tags: [ZAPIER_TAG],
+        },
       })
       .reply(201, [
         {


### PR DESCRIPTION
### Description

While assigning a label directly to an asset directly is currently not possible, we can add a metadata to assets created via Zapier.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Unit tests
- [x] End-to-end tests

### Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation (where applicable).
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
