### PR TITLE
fix: modify the cleanup action to support removal of assets created by Zapier

### DIFF
--- a/docs/available-actions.md
+++ b/docs/available-actions.md
@@ -28,7 +28,7 @@ Do everything in one step:
 
 Maintain your content library:
 
-- Remove Zapier-created playlists
+- Remove playlists and assets created by Zapier
 - Safe deletion with confirmation
 
 ## 5. Assign Screen to Playlist

--- a/src/actions/cleanup-zapier-content.ts
+++ b/src/actions/cleanup-zapier-content.ts
@@ -1,4 +1,5 @@
 import { ZObject, Bundle } from 'zapier-platform-core';
+
 import utils from '../utils.js';
 import { ZAPIER_TAG } from '../constants.js';
 
@@ -40,24 +41,38 @@ const cleanupZapierContent = {
       const playListIds = playlistToLabelMappings.map(
         (mapping: { playlist_id: string }) => mapping.playlist_id
       );
-      let successfulDeletions = 0;
+      let successfulPlaylistDeletions = 0;
+      let successfulAssetDeletions = 0;
 
       // Delete each playlist
       for (const playlistId of playListIds) {
         const success = await utils.deletePlaylist(z, bundle, { playlistId });
         if (success) {
-          successfulDeletions++;
+          successfulPlaylistDeletions++;
+        }
+      }
+
+      const taggedAssets = await utils.getAssetsCreatedByZapier(z, bundle);
+
+      for (const asset of taggedAssets) {
+        const success = await utils.deleteAsset(z, bundle, {
+          assetId: asset.id,
+        });
+        if (success) {
+          successfulAssetDeletions++;
         }
       }
 
       return {
-        playlists_removed: successfulDeletions,
-        message: `Successfully removed ${successfulDeletions} playlists`,
+        playlists_removed: successfulPlaylistDeletions,
+        assets_removed: successfulAssetDeletions,
+        message: `Successfully removed ${successfulPlaylistDeletions} playlists and ${successfulAssetDeletions} assets`,
       };
     },
     sample: {
       playlists_removed: 1,
-      message: 'Successfully removed 1 playlist',
+      assets_removed: 2,
+      message: 'Successfully removed 1 playlist and 2 assets',
     },
   },
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -244,6 +244,48 @@ const deletePlaylist = async (
   return response.status === 200;
 };
 
+const deleteAsset = async (
+  z: ZObject,
+  bundle: Bundle,
+  { assetId }: { assetId: string }
+): Promise<boolean> => {
+  const params = new URLSearchParams({ id: `eq.${assetId}` });
+  const response = await z.request({
+    url: `https://api.screenlyapp.com/api/v4/assets/?${params.toString()}`,
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Token ${bundle.authData.api_key}`,
+      Prefer: 'return=representation',
+    },
+    skipThrowForStatus: true,
+  });
+
+  return response.status === 200;
+};
+
+const getAssetsCreatedByZapier = async (
+  z: ZObject,
+  bundle: Bundle
+): Promise<Asset[]> => {
+  const queryParams = [
+    'metadata->tags=cs.["created_by_zapier"]',
+    'or=(status.eq.downloading,status.eq.processing,status.eq.finished)',
+  ].join('&');
+
+  const response = await z.request({
+    url: `https://api.screenlyapp.com/api/v4/assets/?${queryParams}`,
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Token ${bundle.authData.api_key}`,
+      Prefer: 'return=representation',
+    },
+  });
+
+  return handleError(response, 'Failed to fetch assets');
+};
+
 export default {
   handleError,
   waitForAssetReady,
@@ -254,4 +296,6 @@ export default {
   getLabel,
   getPlaylistsByLabel,
   deletePlaylist,
+  deleteAsset,
+  getAssetsCreatedByZapier,
 };


### PR DESCRIPTION
### Description

- Updates the "Cleanup Zapier Content" action so that assets created by Zapier could be removed as well.

### How Has This Been Tested?

- [x] Unit tests
- [x] End-to-end tests

### Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation (where applicable).
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
