### PR TITLE
refactor: move query params (for asset status) to `constants.ts`

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,4 @@
 export const ZAPIER_TAG = 'created_by_zapier';
 export const READY_STATES = ['downloading', 'processing', 'finished'];
+export const ASSET_STATUS_QUERY =
+  'or=(status.eq.downloading,status.eq.processing,status.eq.finished)';

--- a/src/triggers/get-assets.ts
+++ b/src/triggers/get-assets.ts
@@ -1,5 +1,6 @@
 import { ZObject, Bundle } from 'zapier-platform-core';
 import utils from '../utils.js';
+import { ASSET_STATUS_QUERY } from '../constants.js';
 
 const getAssets = {
   key: 'get_assets',
@@ -13,7 +14,7 @@ const getAssets = {
     perform: async (z: ZObject, bundle: Bundle): Promise<object> => {
       const queryParams = [
         'and=(type.not.eq.edge-app-file,type.not.eq.edge-app)',
-        'or=(status.eq.downloading,status.eq.processing,status.eq.finished)',
+        ASSET_STATUS_QUERY,
       ].join('&');
 
       const response = await z.request({

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,7 @@
 // Utility functions for Screenly Zapier integration
 
 import { ZObject, Bundle, HttpResponse } from 'zapier-platform-core';
-import { READY_STATES, ZAPIER_TAG } from './constants.js';
+import { READY_STATES, ZAPIER_TAG, ASSET_STATUS_QUERY } from './constants.js';
 import {
   Asset,
   PlaylistItem,
@@ -270,7 +270,7 @@ const getAssetsCreatedByZapier = async (
 ): Promise<Asset[]> => {
   const queryParams = [
     'metadata->tags=cs.["created_by_zapier"]',
-    'or=(status.eq.downloading,status.eq.processing,status.eq.finished)',
+    ASSET_STATUS_QUERY,
   ].join('&');
 
   const response = await z.request({

--- a/test/cleanup.test.ts
+++ b/test/cleanup.test.ts
@@ -2,6 +2,7 @@ import zapier from 'zapier-platform-core';
 import App from '../src/index.js';
 import nock from 'nock';
 import { describe, beforeEach, test, expect } from 'vitest';
+import { ASSET_STATUS_QUERY } from '../src/constants.js';
 
 const TEST_API_KEY = 'valid-api-key';
 const appTester = zapier.createAppTester(App);
@@ -59,10 +60,13 @@ describe('Cleanup', () => {
       .reply(200);
 
     // Mock assets created by Zapier
+    const queryParams = [
+      'metadata->tags=cs.["created_by_zapier"]',
+      ASSET_STATUS_QUERY,
+    ].join('&');
+
     nock('https://api.screenlyapp.com')
-      .get(
-        '/api/v4/assets/?metadata->tags=cs.["created_by_zapier"]&or=(status.eq.downloading,status.eq.processing,status.eq.finished)'
-      )
+      .get(`/api/v4/assets/?${queryParams}`)
       .matchHeader('Authorization', `Token ${TEST_API_KEY}`)
       .reply(200, [{ id: 'asset-1' }, { id: 'asset-2' }]);
 

--- a/test/dynamic-dropdowns.test.ts
+++ b/test/dynamic-dropdowns.test.ts
@@ -2,6 +2,7 @@ import zapier from 'zapier-platform-core';
 import App from '../src/index.js';
 import nock from 'nock';
 import { describe, beforeEach, test, expect } from 'vitest';
+import { ASSET_STATUS_QUERY } from '../src/constants.js';
 
 const TEST_API_KEY = 'valid-api-key';
 const appTester = zapier.createAppTester(App);
@@ -44,7 +45,7 @@ describe('Dynamic Dropdowns', () => {
 
     const queryParams = [
       'and=(type.not.eq.edge-app-file,type.not.eq.edge-app)',
-      'or=(status.eq.downloading,status.eq.processing,status.eq.finished)',
+      ASSET_STATUS_QUERY,
     ].join('&');
 
     nock('https://api.screenlyapp.com')


### PR DESCRIPTION
### Description

- This pull request is a follow-up to #59 

### How Has This Been Tested?

- [x] Unit tests
- [x] End-to-end tests

### Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation (where applicable).
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
