### PR TITLE
chore(ci): add a step for creating a GitHub release

### DIFF
--- a/.github/workflows/zapier-release.yml
+++ b/.github/workflows/zapier-release.yml
@@ -45,3 +45,9 @@ jobs:
         env:
           ZAPIER_DEPLOY_KEY: ${{ secrets.ZAPIER_DEPLOY_KEY }}
         run: npm run build && zapier push
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          prerelease: true


### PR DESCRIPTION
### Description

Adds a step for creating a release when a new tag gets pushed.

### Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation (where applicable).
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules