### PR TITLE
chore(ci): add permission necessary to created a GitHub release via CI

### DIFF
--- a/.github/workflows/zapier-release.yml
+++ b/.github/workflows/zapier-release.yml
@@ -7,7 +7,10 @@ on:
 
 jobs:
   deploy:
+    name: Deploy to Zapier
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
### Description

* Adds a write permission to contents so that a GitHub release can be created via CI

### Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation (where applicable).
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules