### PR TITLE
feat: add support for scheduling a new asset to a playlist

### DIFF
--- a/docs/available-actions.md
+++ b/docs/available-actions.md
@@ -8,11 +8,12 @@ Upload files to your Screenly account:
 - Set custom titles and durations
 - Accepts files via URL or direct upload
 
-## 2. Add to Playlist
+## 2. Add Asset to Playlist
 
 Add content to your playlists:
 
 - Choose from your existing playlists
+- Either create a new asset or use an existing asset
 - Set display duration
 
 ## 3. Complete Workflow

--- a/src/actions/schedule-playlist-item.ts
+++ b/src/actions/schedule-playlist-item.ts
@@ -19,12 +19,30 @@ const schedulePlaylistItem = {
         helpText: 'Select the playlist',
       },
       {
+        key: 'is_new_asset',
+        label: 'Create a new asset?',
+        type: 'boolean',
+        required: true,
+        helpText: 'Create a new asset?',
+      },
+      {
         key: 'asset_id',
         label: 'Asset',
         type: 'string',
-        required: true,
+        required: false,
         dynamic: 'get_assets.id.title',
         helpText: 'Select the asset to schedule',
+      },
+      {
+        key: 'file',
+        label: 'File URL',
+        type: 'string',
+        required: true,
+        helpText: 'The URL of the file to upload',
+      },
+      {
+        key: 'title',
+        label: 'Title of the asset',
       },
       {
         key: 'duration',
@@ -46,8 +64,21 @@ const schedulePlaylistItem = {
         bundle.authData.api_key
       );
 
+      let assetId = null;
+      const isNewAsset = bundle.inputData.is_new_asset;
+
+      if (isNewAsset) {
+        const asset = await utils.createAsset(z, bundle, {
+          title: bundle.inputData.title,
+          sourceUrl: bundle.inputData.file,
+        });
+        assetId = asset.id;
+      } else {
+        assetId = bundle.inputData.asset_id;
+      }
+
       return await utils.createPlaylistItem(z, bundle, {
-        assetId: bundle.inputData.asset_id,
+        assetId: assetId,
         playlistId: bundle.inputData.playlist_id,
         duration: bundle.inputData.duration,
       });

--- a/src/actions/schedule-playlist-item.ts
+++ b/src/actions/schedule-playlist-item.ts
@@ -61,12 +61,6 @@ const schedulePlaylistItem = {
         throw new Error('API key is required');
       }
 
-      await utils.waitForAssetReady(
-        z,
-        bundle.inputData.asset_id,
-        bundle.authData.api_key
-      );
-
       let assetId = null;
       const isNewAsset = bundle.inputData.is_new_asset;
 
@@ -80,8 +74,10 @@ const schedulePlaylistItem = {
         assetId = bundle.inputData.asset_id;
       }
 
+      await utils.waitForAssetReady(z, assetId, bundle.authData.api_key);
+
       return await utils.createPlaylistItem(z, bundle, {
-        assetId: assetId,
+        assetId,
         playlistId: bundle.inputData.playlist_id,
         duration: bundle.inputData.duration,
       });

--- a/src/actions/schedule-playlist-item.ts
+++ b/src/actions/schedule-playlist-item.ts
@@ -37,12 +37,15 @@ const schedulePlaylistItem = {
         key: 'file',
         label: 'File URL',
         type: 'string',
-        required: true,
+        required: false,
         helpText: 'The URL of the file to upload',
       },
       {
         key: 'title',
-        label: 'Title of the asset',
+        label: 'Title',
+        type: 'string',
+        required: false,
+        helpText: 'Title of the asset',
       },
       {
         key: 'duration',


### PR DESCRIPTION
### Description

Modified the **_Add Asset to Playlist_** action so that assigning an asset that was just created is supported.

### How Has This Been Tested?

- [ ] Unit tests
- [ ] End-to-end tests

### Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation (where applicable).
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
